### PR TITLE
Feature/background

### DIFF
--- a/src/Components/Background/index.tsx
+++ b/src/Components/Background/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import * as S from "./style";
+
+interface brownBoxVisibleProps{
+  visible: boolean;
+}
+
+const Background: React.FC<brownBoxVisibleProps> = ({visible}) => {
+  return (
+    <S.Background>
+      <S.PinkBackground visible={visible} />
+      {visible && <S.BrownBackground />}
+    </S.Background>
+  );
+}
+
+export default Background;

--- a/src/Components/Background/index.tsx
+++ b/src/Components/Background/index.tsx
@@ -8,8 +8,9 @@ interface brownBoxVisibleProps{
 const Background: React.FC<brownBoxVisibleProps> = ({brownBoxVisible}) => {
   return (
     <S.Background>
-      <S.PinkBackground brownBoxVisible={brownBoxVisible} />
-      {brownBoxVisible && <S.BrownBackground />}
+      <S.PinkBackground>
+        {brownBoxVisible && <S.BrownBackground />}
+      </S.PinkBackground>
     </S.Background>
   );
 }

--- a/src/Components/Background/index.tsx
+++ b/src/Components/Background/index.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import * as S from "./style";
 
 interface brownBoxVisibleProps{
-  visible: boolean;
+  brownBoxVisible: boolean;
 }
 
-const Background: React.FC<brownBoxVisibleProps> = ({visible}) => {
+const Background: React.FC<brownBoxVisibleProps> = ({brownBoxVisible}) => {
   return (
     <S.Background>
-      <S.PinkBackground visible={visible} />
-      {visible && <S.BrownBackground />}
+      <S.PinkBackground brownBoxVisible={brownBoxVisible} />
+      {brownBoxVisible && <S.BrownBackground />}
     </S.Background>
   );
 }

--- a/src/Components/Background/style.ts
+++ b/src/Components/Background/style.ts
@@ -1,23 +1,21 @@
 import styled from "styled-components";
 
-interface brownBoxVisibleProps {
-  brownBoxVisible: boolean;
-}
-
 export const Background = styled.div`
   width: 600px;
   margin: 0 auto;
   box-shadow: 4px 4px 100px 50px rgba(253, 87, 147, 0.25);
 `;
 
-export const PinkBackground = styled.div<brownBoxVisibleProps>`
+export const PinkBackground = styled.div`
   width: 100%;
-  height: ${({brownBoxVisible})=> (brownBoxVisible ? 65 : 100)}vh;
+  height: 100vh;
   background-color: #ffecdb;
 `;
 
 export const BrownBackground = styled.div`
-  width: 100%;
+  width: 600px;
   height: 35vh;
+  position: absolute;
+  bottom: 0;
   background-color: #885252;
 `;

--- a/src/Components/Background/style.ts
+++ b/src/Components/Background/style.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+interface brownBoxVisibleProps {
+  visible: boolean;
+}
+
+export const Background = styled.div`
+  width: 600px;
+  margin: 0 auto;
+  box-shadow: 4px 4px 100px 50px rgba(253, 87, 147, 0.25);
+`;
+
+export const PinkBackground = styled.div<brownBoxVisibleProps>`
+  width: 100%;
+  height: ${({visible})=> (visible ? 65 : 100)}vh;
+  background-color: #ffecdb;
+`;
+
+export const BrownBackground = styled.div`
+  width: 100%;
+  height: 35vh;
+  background-color: #885252;
+`;

--- a/src/Components/Background/style.ts
+++ b/src/Components/Background/style.ts
@@ -13,9 +13,9 @@ export const PinkBackground = styled.div`
 `;
 
 export const BrownBackground = styled.div`
-  width: 600px;
+  width: 100%;
   height: 35vh;
-  position: absolute;
-  bottom: 0;
+  position: relative;
+  top: 65vh;
   background-color: #885252;
 `;

--- a/src/Components/Background/style.ts
+++ b/src/Components/Background/style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 interface brownBoxVisibleProps {
-  visible: boolean;
+  brownBoxVisible: boolean;
 }
 
 export const Background = styled.div`
@@ -12,7 +12,7 @@ export const Background = styled.div`
 
 export const PinkBackground = styled.div<brownBoxVisibleProps>`
   width: 100%;
-  height: ${({visible})=> (visible ? 65 : 100)}vh;
+  height: ${({brownBoxVisible})=> (brownBoxVisible ? 65 : 100)}vh;
   background-color: #ffecdb;
 `;
 


### PR DESCRIPTION
# 배경 추가

## 사용법

Background component 사용시 ```brownBoxVisible={true}```와 같이 props를 넘겨준다

true = brown box가 생깁니다
<img width="2048" alt="스크린샷 2022-01-15 오전 1 58 00" src="https://user-images.githubusercontent.com/80103328/149554895-6375467e-adc1-4788-b5bc-51ed4f309db3.png">

false = brown box가 생기지 않습니다
<img width="2048" alt="스크린샷 2022-01-15 오전 1 58 12" src="https://user-images.githubusercontent.com/80103328/149554922-10795364-f03e-470c-b7c6-91e3ae56b1f1.png">

