### PR TITLE
Background maxHeight media쿼리 추가

### DIFF
--- a/src/Components/Background/index.tsx
+++ b/src/Components/Background/index.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import * as S from "./style";
 
 interface brownBoxVisibleProps{
-  brownBoxVisible: boolean;
-}
+  brownBoxVisible: boolean,
+  maxHeight: number,
+};
 
-const Background: React.FC<brownBoxVisibleProps> = ({brownBoxVisible}) => {
+const Background: React.FC<brownBoxVisibleProps> = ({brownBoxVisible, maxHeight}) => {
   return (
-    <S.Background>
+    <S.Background maxHeight={maxHeight}>
       <S.PinkBackground>
         {brownBoxVisible && <S.BrownBackground />}
       </S.PinkBackground>

--- a/src/Components/Background/style.ts
+++ b/src/Components/Background/style.ts
@@ -1,13 +1,20 @@
 import styled from "styled-components";
 import device from "../../Shared/Config";
 
-export const Background = styled.div`
+interface maxHeightType{
+  maxHeight:number,
+};
+
+export const Background = styled.div<maxHeightType>`
   width: 600px;
   height: 100%;
   box-shadow: 4px 4px 100px 50px rgba(253, 87, 147, 0.25);
   position: absolute;
   @media ${device.mobile} {
     width: 100vw;
+  }
+  @media (max-height: ${({ maxHeight }) => maxHeight}px) and (min-width: 600px) {
+    height: ${({ maxHeight }) => maxHeight}px;
   }
 `;
 
@@ -19,8 +26,8 @@ export const PinkBackground = styled.div`
 
 export const BrownBackground = styled.div`
   width: 100%;
-  height: 35vh;
+  height: 35%;
   position: relative;
-  top: 65vh;
+  top: 65%;
   background-color: #885252;
 `;


### PR DESCRIPTION
## 개요 💡

> background에 width > 600px 일때의 최소 사이즈를 정하기 위한 기능 추가

## 작업내용 ⌨️

> Background를 사용할때 자신의 페이지가 스크롤 되는 height를 maxHeight로 props로 준다

예시
<img width="453" alt="스크린샷 2022-01-25 오전 10 41 51" src="https://user-images.githubusercontent.com/80103328/150894977-2790c121-bfbc-4520-b6f2-34728ca1c1a3.png">